### PR TITLE
refactor: cut() doesn't need &mut self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl<'a> FastCDC<'a> {
     }
 
     /// Returns the size of the next chunk.
-    fn cut(&mut self, mut source_offset: usize, mut source_size: usize) -> (u32, usize) {
+    fn cut(&self, mut source_offset: usize, mut source_size: usize) -> (u32, usize) {
         if source_size <= self.min_size {
             if !self.eof {
                 (0, 0)


### PR DESCRIPTION
Make it more clear that cut doesn't mutate anything inside the FastCDC struct itself.