### PR TITLE
Support conversion to std::io::Error

### DIFF
--- a/src/v2016/mod.rs
+++ b/src/v2016/mod.rs
@@ -418,6 +418,16 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::IoError(ioerr) => ioerr,
+            Error::Empty => Self::from(std::io::ErrorKind::UnexpectedEof),
+            Error::Other(str) => Self::new(std::io::ErrorKind::Other, str),
+        }
+    }
+}
+
 ///
 /// Represents a chunk returned from the StreamCDC iterator.
 ///

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -506,6 +506,16 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::IoError(ioerr) => ioerr,
+            Error::Empty => Self::from(std::io::ErrorKind::UnexpectedEof),
+            Error::Other(str) => Self::new(std::io::ErrorKind::Other, str),
+        }
+    }
+}
+
 ///
 /// Represents a chunk returned from the StreamCDC iterator.
 ///


### PR DESCRIPTION
This adds a convenience conversion to std::io::Error. Do you want a test for this?