### PR TITLE
feat!: Enhanced `AsyncStreamCDC`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Run cargo test (futures)
+      - name: Run cargo test (async/tokio)
         uses: actions-rs/cargo@v1
         with:
-          command: test --no-default-features --features futures
+          command: test --features tokio
+      - name: Run cargo test (async/futures)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --features futures
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ on: [push, pull_request]
 name: Test
 jobs:
   build:
-    name: Build 
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo 
+      - name: Checkout repo
         uses: actions/checkout@v2
 
       - name: Install rust stable toolchain
@@ -15,10 +15,10 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run cargo build 
+      - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
-          command: build 
+          command: build
 
   test:
     name: Test
@@ -38,6 +38,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Run cargo test (futures)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --no-default-features --features futures
 
   lints:
     name: Lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,13 @@ jobs:
       - name: Run cargo test (async/tokio)
         uses: actions-rs/cargo@v1
         with:
-          command: test --features tokio
+          command: test
+          args: --features tokio
       - name: Run cargo test (async/futures)
         uses: actions-rs/cargo@v1
         with:
-          command: test --features futures
+          command: test
+          args: --features futures
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ exclude = [
     "test/*",
 ]
 
+[features]
+default = ["tokio"]
+tokio = ["dep:tokio", "tokio-stream", "async-stream"]
+futures = ["dep:futures"]
+
+
 [dev-dependencies]
 aes = "0.8.2"
 byteorder = "1.4.3"
@@ -20,6 +26,12 @@ clap = { version = "4.2.1", features = ["cargo"] }
 ctr = "0.9.2"
 md-5 = "0.10.5"
 memmap2 = "0.5.8"
+tokio = { version = "1.29.1", features = ["io-util", "rt", "macros"] }
+futures-test = { version = "0.3.28" }
 
 [dependencies]
-futures = "0.3.28"
+futures = { version = "0.3.28", optional = true }
+tokio = { version = "1.29.1", features = ["io-util"], optional = true }
+tokio-stream = { version = "0.1.14", optional = true }
+async-stream = { version = "0.3.5", optional = true }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ clap = { version = "4.2.1", features = ["cargo"] }
 ctr = "0.9.2"
 md-5 = "0.10.5"
 memmap2 = "0.5.8"
-tokio = { version = "1.29.1", features = ["io-util", "rt", "macros"] }
-futures-test = { version = "0.3.28" }
+tokio = { version = "1", features = ["io-util", "rt", "macros"] }
+futures-test = { version = "0.3" }
 
 [dependencies]
-futures = { version = "0.3.28", optional = true }
-tokio = { version = "1.29.1", features = ["io-util"], optional = true }
-tokio-stream = { version = "0.1.14", optional = true }
-async-stream = { version = "0.3.5", optional = true }
+futures = { version = "0.3", optional = true }
+tokio = { version = "1", features = ["io-util"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
+async-stream = { version = "0.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [features]
-default = ["tokio"]
+default = []
 tokio = ["dep:tokio", "tokio-stream", "async-stream"]
 futures = ["dep:futures"]
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ for result in chunker {
 }
 ```
 
+### Async Streaming
+
+The `v2020` module has an async streaming version of FastCDC named `AsyncStreamCDC`, which takes an `AsyncRead` (both `tokio` and `futures` are supported via feature flags) and uses a byte vector with capacity equal to the specified maximum chunk size.
+
+```rust
+let source = std::fs::File::open("test/fixtures/SekienAkashita.jpg").unwrap();
+let chunker = fastcdc::v2020::AsyncStreamCDC::new(&source, 4096, 16384, 65535);
+let stream = chunker.as_stream();
+let chunks = stream.collect::<Vec<_>>().await;
+
+for result in chunks {
+    let chunk = result.unwrap();
+    println!("offset={} length={}", chunk.offset, chunk.length);
+}
+```
+
 ## Migration from pre-3.0
 
 If you were using a release of this crate from before the 3.0 release, you will need to make a small adjustment to continue using the same implementation as before.

--- a/src/v2020/async_stream_cdc.rs
+++ b/src/v2020/async_stream_cdc.rs
@@ -42,15 +42,17 @@ use async_stream::try_stream;
 /// # #[cfg(all(feature = "tokio", not(feature = "futures")))]
 /// # use tokio_stream::StreamExt;
 ///
-/// let source = File::open("test/fixtures/SekienAkashita.jpg").unwrap();
-/// let chunker = AsyncStreamCDC::new(&source, 4096, 16384, 65535);
-/// let stream = chunker.as_stream();
+/// async fn run() {
+///     let source = std::fs::read("test/fixtures/SekienAkashita.jpg").unwrap();
+///     let mut chunker = AsyncStreamCDC::new(source.as_ref(), 4096, 16384, 65535);
+///     let stream = chunker.as_stream();
 ///
-/// let chunks = stream.collect::<Vec<_>>().await;
+///     let chunks = stream.collect::<Vec<_>>().await;
 ///
-/// for result in chunks {
-///     let chunk = result.unwrap();
-///     println!("offset={} length={}", chunk.offset, chunk.length);
+///     for result in chunks {
+///         let chunk = result.unwrap();
+///         println!("offset={} length={}", chunk.offset, chunk.length);
+///     }
 /// }
 /// ```
 ///

--- a/src/v2020/async_stream_cdc.rs
+++ b/src/v2020/async_stream_cdc.rs
@@ -1,0 +1,366 @@
+//
+// Copyright (c) 2023 Nathan Fiedler
+//
+
+use super::*;
+
+#[cfg(all(feature = "futures", not(feature = "tokio")))]
+use futures::{
+    io::{AsyncRead, AsyncReadExt},
+    stream::Stream,
+};
+
+#[cfg(all(feature = "tokio", not(feature = "futures")))]
+use tokio_stream::Stream;
+
+#[cfg(all(feature = "tokio", not(feature = "futures")))]
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+#[cfg(all(feature = "tokio", not(feature = "futures")))]
+use async_stream::try_stream;
+
+///
+/// An async-streamable version of the FastCDC chunker implementation from 2020
+/// with streaming support.
+///
+/// Use `new` to construct an instance, and then `as_stream` to produce an async
+/// [Stream] of the chunks.
+///
+/// Both `futures` and `tokio`-based [AsyncRead] inputs are supported via
+/// feature flags. But, if necessary you can also use the
+/// [`async_compat`](https://docs.rs/async-compat/latest/async_compat/) crate to
+/// adapt your inputs as circumstances may require.
+///
+/// Note that this struct allocates a `Vec<u8>` of `max_size` bytes to act as a
+/// buffer when reading from the source and finding chunk boundaries.
+///
+/// ```no_run
+/// # use std::fs::File;
+/// # use fastcdc::v2020::AsyncStreamCDC;
+/// # #[cfg(all(feature = "futures", not(feature = "tokio")))]
+/// # use futures::stream::StreamExt;
+/// # #[cfg(all(feature = "tokio", not(feature = "futures")))]
+/// # use tokio_stream::StreamExt;
+///
+/// let source = File::open("test/fixtures/SekienAkashita.jpg").unwrap();
+/// let chunker = AsyncStreamCDC::new(&source, 4096, 16384, 65535);
+/// let stream = chunker.as_stream();
+///
+/// let chunks = stream.collect::<Vec<_>>().await;
+///
+/// for result in chunks {
+///     let chunk = result.unwrap();
+///     println!("offset={} length={}", chunk.offset, chunk.length);
+/// }
+/// ```
+///
+pub struct AsyncStreamCDC<R> {
+    /// Buffer of data from source for finding cut points.
+    buffer: Vec<u8>,
+    /// Maximum capacity of the buffer (always `max_size`).
+    capacity: usize,
+    /// Number of relevant bytes in the `buffer`.
+    length: usize,
+    /// Source from which data is read into `buffer`.
+    source: R,
+    /// Number of bytes read from the source so far.
+    processed: u64,
+    /// True when the source produces no more data.
+    eof: bool,
+    min_size: usize,
+    avg_size: usize,
+    max_size: usize,
+    mask_s: u64,
+    mask_l: u64,
+    mask_s_ls: u64,
+    mask_l_ls: u64,
+}
+
+impl<R: AsyncRead + Unpin> AsyncStreamCDC<R> {
+    ///
+    /// Construct a `StreamCDC` that will process bytes from the given source.
+    ///
+    /// Uses chunk size normalization level 1 by default.
+    ///
+    pub fn new(source: R, min_size: u32, avg_size: u32, max_size: u32) -> Self {
+        Self::with_level(source, min_size, avg_size, max_size, Normalization::Level1)
+    }
+
+    ///
+    /// Create a new `StreamCDC` with the given normalization level.
+    ///
+    pub fn with_level(
+        source: R,
+        min_size: u32,
+        avg_size: u32,
+        max_size: u32,
+        level: Normalization,
+    ) -> Self {
+        assert!(min_size >= MINIMUM_MIN);
+        assert!(min_size <= MINIMUM_MAX);
+        assert!(avg_size >= AVERAGE_MIN);
+        assert!(avg_size <= AVERAGE_MAX);
+        assert!(max_size >= MAXIMUM_MIN);
+        assert!(max_size <= MAXIMUM_MAX);
+        let bits = logarithm2(avg_size);
+        let normalization = level.bits();
+        let mask_s = MASKS[(bits + normalization) as usize];
+        let mask_l = MASKS[(bits - normalization) as usize];
+        Self {
+            buffer: vec![0_u8; max_size as usize],
+            capacity: max_size as usize,
+            length: 0,
+            source,
+            eof: false,
+            processed: 0,
+            min_size: min_size as usize,
+            avg_size: avg_size as usize,
+            max_size: max_size as usize,
+            mask_s,
+            mask_l,
+            mask_s_ls: mask_s << 1,
+            mask_l_ls: mask_l << 1,
+        }
+    }
+
+    /// Fill the buffer with data from the source, returning the number of bytes
+    /// read (zero if end of source has been reached).
+    async fn fill_buffer(&mut self) -> Result<usize, Error> {
+        // this code originally copied from asuran crate
+        if self.eof {
+            Ok(0)
+        } else {
+            let mut all_bytes_read = 0;
+            while !self.eof && self.length < self.capacity {
+                let bytes_read = self.source.read(&mut self.buffer[self.length..]).await?;
+                if bytes_read == 0 {
+                    self.eof = true;
+                } else {
+                    self.length += bytes_read;
+                    all_bytes_read += bytes_read;
+                }
+            }
+            Ok(all_bytes_read)
+        }
+    }
+
+    /// Drains a specified number of bytes from the buffer, then resizes the
+    /// buffer back to `capacity` size in preparation for further reads.
+    fn drain_bytes(&mut self, count: usize) -> Result<Vec<u8>, Error> {
+        // this code originally copied from asuran crate
+        if count > self.length {
+            Err(Error::Other(format!(
+                "drain_bytes() called with count larger than length: {} > {}",
+                count, self.length
+            )))
+        } else {
+            let data = self.buffer.drain(..count).collect::<Vec<u8>>();
+            self.length -= count;
+            self.buffer.resize(self.capacity, 0_u8);
+            Ok(data)
+        }
+    }
+
+    /// Find the next chunk in the source. If the end of the source has been
+    /// reached, returns `Error::Empty` as the error.
+    async fn read_chunk(&mut self) -> Result<ChunkData, Error> {
+        self.fill_buffer().await?;
+        if self.length == 0 {
+            Err(Error::Empty)
+        } else {
+            let (hash, count) = cut(
+                &self.buffer[..self.length],
+                self.min_size,
+                self.avg_size,
+                self.max_size,
+                self.mask_s,
+                self.mask_l,
+                self.mask_s_ls,
+                self.mask_l_ls,
+            );
+            if count == 0 {
+                Err(Error::Empty)
+            } else {
+                let offset = self.processed;
+                self.processed += count as u64;
+                let data = self.drain_bytes(count)?;
+                Ok(ChunkData {
+                    hash,
+                    offset,
+                    length: count,
+                    data,
+                })
+            }
+        }
+    }
+
+    #[cfg(all(feature = "tokio", not(feature = "futures")))]
+    pub fn as_stream(&mut self) -> impl Stream<Item = Result<ChunkData, Error>> + '_ {
+        try_stream! {
+            loop {
+                match self.read_chunk().await {
+                    Ok(chunk) => yield chunk,
+                    Err(Error::Empty) => {
+                        break;
+                    }
+                    error @ Err(_) => {
+                        error?;
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(all(feature = "futures", not(feature = "tokio")))]
+    pub fn as_stream(&mut self) -> impl Stream<Item = Result<ChunkData, Error>> + '_ {
+        futures::stream::unfold(self, |this| async {
+            let chunk = this.read_chunk().await;
+            if let Err(Error::Empty) = chunk {
+                None
+            } else {
+                Some((chunk, this))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v2020::MASKS;
+
+    use super::AsyncStreamCDC;
+
+    #[test]
+    #[should_panic]
+    fn test_minimum_too_low() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 63, 256, 1024);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_minimum_too_high() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 67_108_867, 256, 1024);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_average_too_low() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 64, 255, 1024);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_average_too_high() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 64, 268_435_457, 1024);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_maximum_too_low() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 64, 256, 1023);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_maximum_too_high() {
+        let array = [0u8; 1024];
+        AsyncStreamCDC::new(array.as_slice(), 64, 256, 1_073_741_825);
+    }
+
+    #[test]
+    fn test_masks() {
+        let source = [0u8; 1024];
+        let chunker = AsyncStreamCDC::new(source.as_slice(), 64, 256, 1024);
+        assert_eq!(chunker.mask_l, MASKS[7]);
+        assert_eq!(chunker.mask_s, MASKS[9]);
+        let chunker = AsyncStreamCDC::new(source.as_slice(), 8192, 16384, 32768);
+        assert_eq!(chunker.mask_l, MASKS[13]);
+        assert_eq!(chunker.mask_s, MASKS[15]);
+        let chunker = AsyncStreamCDC::new(source.as_slice(), 1_048_576, 4_194_304, 16_777_216);
+        assert_eq!(chunker.mask_l, MASKS[21]);
+        assert_eq!(chunker.mask_s, MASKS[23]);
+    }
+
+    struct ExpectedChunk {
+        hash: u64,
+        offset: u64,
+        length: usize,
+        digest: String,
+    }
+
+    use md5::{Digest, Md5};
+
+    #[cfg(all(feature = "futures", not(feature = "tokio")))]
+    use futures::stream::StreamExt;
+    #[cfg(all(feature = "tokio", not(feature = "futures")))]
+    use tokio_stream::StreamExt;
+
+    #[cfg_attr(all(feature = "tokio", not(feature = "futures")), tokio::test)]
+    #[cfg_attr(all(feature = "futures", not(feature = "tokio")), futures_test::test)]
+    async fn test_iter_sekien_16k_chunks() {
+        let read_result = std::fs::read("test/fixtures/SekienAkashita.jpg");
+        assert!(read_result.is_ok());
+        let contents = read_result.unwrap();
+        // The digest values are not needed here, but they serve to validate
+        // that the streaming version tested below is returning the correct
+        // chunk data on each iteration.
+        let expected_chunks = vec![
+            ExpectedChunk {
+                hash: 17968276318003433923,
+                offset: 0,
+                length: 21325,
+                digest: "2bb52734718194617c957f5e07ee6054".into(),
+            },
+            ExpectedChunk {
+                hash: 8197189939299398838,
+                offset: 21325,
+                length: 17140,
+                digest: "badfb0757fe081c20336902e7131f768".into(),
+            },
+            ExpectedChunk {
+                hash: 13019990849178155730,
+                offset: 38465,
+                length: 28084,
+                digest: "18412d7414de6eb42f638351711f729d".into(),
+            },
+            ExpectedChunk {
+                hash: 4509236223063678303,
+                offset: 66549,
+                length: 18217,
+                digest: "04fe1405fc5f960363bfcd834c056407".into(),
+            },
+            ExpectedChunk {
+                hash: 2504464741100432583,
+                offset: 84766,
+                length: 24700,
+                digest: "1aa7ad95f274d6ba34a983946ebc5af3".into(),
+            },
+        ];
+        let mut chunker = AsyncStreamCDC::new(contents.as_ref(), 4096, 16384, 65535);
+        let stream = chunker.as_stream();
+
+        let chunks = stream.collect::<Vec<_>>().await;
+
+        let mut index = 0;
+
+        for chunk in chunks {
+            let chunk = chunk.unwrap();
+            assert_eq!(chunk.hash, expected_chunks[index].hash);
+            assert_eq!(chunk.offset, expected_chunks[index].offset);
+            assert_eq!(chunk.length, expected_chunks[index].length);
+            let mut hasher = Md5::new();
+            hasher
+                .update(&contents[(chunk.offset as usize)..(chunk.offset as usize) + chunk.length]);
+            let table = hasher.finalize();
+            let digest = format!("{:x}", table);
+            assert_eq!(digest, expected_chunks[index].digest);
+            index += 1;
+        }
+        assert_eq!(index, 5);
+    }
+}

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -34,7 +34,9 @@
 use std::fmt;
 use std::io::Read;
 
+#[cfg(any(feature = "tokio", feature = "futures"))]
 mod async_stream_cdc;
+#[cfg(any(feature = "tokio", feature = "futures"))]
 pub use async_stream_cdc::*;
 
 /// Smallest acceptable value for the minimum chunk size.

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -34,9 +34,8 @@
 use std::fmt;
 use std::io::Read;
 
-use futures::io::AsyncRead;
-use futures::io::AsyncReadExt;
-use futures::stream::Stream;
+mod async_stream_cdc;
+pub use async_stream_cdc::*;
 
 /// Smallest acceptable value for the minimum chunk size.
 pub const MINIMUM_MIN: u32 = 64;
@@ -59,7 +58,7 @@ pub const MAXIMUM_MAX: u32 = 16_777_216;
 // the deduplication ratio is slightly improved when the mask bits are spread
 // relatively evenly, hence these seemingly "magic" values.
 //
-const MASKS: [u64; 26] = [
+pub(self) const MASKS: [u64; 26] = [
     0,                  // padding
     0,                  // padding
     0,                  // padding
@@ -239,7 +238,7 @@ const GEAR_LS: [u64; 256] = [
 
 // Find the next chunk cut point in the source.
 #[allow(clippy::too_many_arguments)]
-fn cut(
+pub(self) fn cut(
     source: &[u8],
     min_size: usize,
     avg_size: usize,
@@ -317,7 +316,7 @@ pub enum Normalization {
 }
 
 impl Normalization {
-    fn bits(&self) -> u32 {
+    pub(self) fn bits(&self) -> u32 {
         match self {
             Normalization::Level0 => 0,
             Normalization::Level1 => 1,
@@ -711,162 +710,10 @@ impl<R: Read> Iterator for StreamCDC<R> {
     }
 }
 
-pub struct AsyncStreamCDC<R> {
-    /// Buffer of data from source for finding cut points.
-    buffer: Vec<u8>,
-    /// Maximum capacity of the buffer (always `max_size`).
-    capacity: usize,
-    /// Number of relevant bytes in the `buffer`.
-    length: usize,
-    /// Source from which data is read into `buffer`.
-    source: R,
-    /// Number of bytes read from the source so far.
-    processed: u64,
-    /// True when the source produces no more data.
-    eof: bool,
-    min_size: usize,
-    avg_size: usize,
-    max_size: usize,
-    mask_s: u64,
-    mask_l: u64,
-    mask_s_ls: u64,
-    mask_l_ls: u64,
-}
-
-impl<R: AsyncRead + std::marker::Unpin> AsyncStreamCDC<R> {
-    ///
-    /// Construct a `StreamCDC` that will process bytes from the given source.
-    ///
-    /// Uses chunk size normalization level 1 by default.
-    ///
-    pub fn new(source: R, min_size: u32, avg_size: u32, max_size: u32) -> Self {
-        Self::with_level(source, min_size, avg_size, max_size, Normalization::Level1)
-    }
-
-    ///
-    /// Create a new `StreamCDC` with the given normalization level.
-    ///
-    pub fn with_level(
-        source: R,
-        min_size: u32,
-        avg_size: u32,
-        max_size: u32,
-        level: Normalization,
-    ) -> Self {
-        assert!(min_size >= MINIMUM_MIN);
-        assert!(min_size <= MINIMUM_MAX);
-        assert!(avg_size >= AVERAGE_MIN);
-        assert!(avg_size <= AVERAGE_MAX);
-        assert!(max_size >= MAXIMUM_MIN);
-        assert!(max_size <= MAXIMUM_MAX);
-        let bits = logarithm2(avg_size);
-        let normalization = level.bits();
-        let mask_s = MASKS[(bits + normalization) as usize];
-        let mask_l = MASKS[(bits - normalization) as usize];
-        Self {
-            buffer: vec![0_u8; max_size as usize],
-            capacity: max_size as usize,
-            length: 0,
-            source,
-            eof: false,
-            processed: 0,
-            min_size: min_size as usize,
-            avg_size: avg_size as usize,
-            max_size: max_size as usize,
-            mask_s,
-            mask_l,
-            mask_s_ls: mask_s << 1,
-            mask_l_ls: mask_l << 1,
-        }
-    }
-
-    /// Fill the buffer with data from the source, returning the number of bytes
-    /// read (zero if end of source has been reached).
-    async fn fill_buffer(&mut self) -> Result<usize, Error> {
-        // this code originally copied from asuran crate
-        if self.eof {
-            Ok(0)
-        } else {
-            let mut all_bytes_read = 0;
-            while !self.eof && self.length < self.capacity {
-                let bytes_read = self.source.read(&mut self.buffer[self.length..]).await?;
-                if bytes_read == 0 {
-                    self.eof = true;
-                } else {
-                    self.length += bytes_read;
-                    all_bytes_read += bytes_read;
-                }
-            }
-            Ok(all_bytes_read)
-        }
-    }
-
-    /// Drains a specified number of bytes from the buffer, then resizes the
-    /// buffer back to `capacity` size in preparation for further reads.
-    fn drain_bytes(&mut self, count: usize) -> Result<Vec<u8>, Error> {
-        // this code originally copied from asuran crate
-        if count > self.length {
-            Err(Error::Other(format!(
-                "drain_bytes() called with count larger than length: {} > {}",
-                count, self.length
-            )))
-        } else {
-            let data = self.buffer.drain(..count).collect::<Vec<u8>>();
-            self.length -= count;
-            self.buffer.resize(self.capacity, 0_u8);
-            Ok(data)
-        }
-    }
-
-    /// Find the next chunk in the source. If the end of the source has been
-    /// reached, returns `Error::Empty` as the error.
-    async fn read_chunk(&mut self) -> Result<ChunkData, Error> {
-        self.fill_buffer().await?;
-        if self.length == 0 {
-            Err(Error::Empty)
-        } else {
-            let (hash, count) = cut(
-                &self.buffer[..self.length],
-                self.min_size,
-                self.avg_size,
-                self.max_size,
-                self.mask_s,
-                self.mask_l,
-                self.mask_s_ls,
-                self.mask_l_ls,
-            );
-            if count == 0 {
-                Err(Error::Empty)
-            } else {
-                let offset = self.processed;
-                self.processed += count as u64;
-                let data = self.drain_bytes(count)?;
-                Ok(ChunkData {
-                    hash,
-                    offset,
-                    length: count,
-                    data,
-                })
-            }
-        }
-    }
-
-    pub fn as_stream(&mut self) -> impl Stream<Item = Result<ChunkData, Error>> + '_ {
-        futures::stream::unfold(self, |this| async {
-            let chunk = this.read_chunk().await;
-            if let Err(Error::Empty) = chunk {
-                None
-            } else {
-                Some((chunk, this))
-            }
-        })
-    }
-}
-
 ///
 /// Base-2 logarithm function for unsigned 32-bit integers.
 ///
-fn logarithm2(value: u32) -> u32 {
+pub(self) fn logarithm2(value: u32) -> u32 {
     f64::from(value).log2().round() as u32
 }
 


### PR DESCRIPTION
- Support both `tokio` and `futures` via feature flags
- Add documentation and usage examples for `AsyncStreamCDC`
- Add tests that specifically target `AsyncStreamCDC`
- Run both `tokio` and `futures`-based tests in CI

Fixes #31 