### PR TITLE
Enable `futures` feature for docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ exclude = [
     "test/*",
 ]
 
+[package.metadata.docs.rs]
+features = ["futures"]
+
 [features]
 default = []
 tokio = ["dep:tokio", "tokio-stream", "async-stream"]


### PR DESCRIPTION
The docs at docs.rs do not include `AsyncStreamCDC`. This fixes that by making sure the `futures` feature is enabled. I picked that feature as it has less dependencies, and `--all-features` would mean that `as_stream` would not be included, as the current `cfg` flags output neither version when both features are enabled.