### PR TITLE
make v2020::get_gear_with_seed public to make cut usable again

### DIFF
--- a/src/v2020/async_stream_cdc.rs
+++ b/src/v2020/async_stream_cdc.rs
@@ -199,8 +199,8 @@ impl<R: AsyncRead + Unpin> AsyncStreamCDC<R> {
                 self.mask_l,
                 self.mask_s_ls,
                 self.mask_l_ls,
-                *self.gear,
-                *self.gear_ls,
+                &self.gear,
+                &self.gear_ls,
             );
             if count == 0 {
                 Err(Error::Empty)

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -277,8 +277,8 @@ pub fn cut(
     mask_l: u64,
     mask_s_ls: u64,
     mask_l_ls: u64,
-    gear: [u64; 256],
-    gear_ls: [u64; 256],
+    gear: &[u64; 256],
+    gear_ls: &[u64; 256],
 ) -> (u64, usize) {
     let mut remaining = source.len();
     if remaining <= min_size {
@@ -504,8 +504,8 @@ impl<'a> FastCDC<'a> {
             self.mask_l,
             self.mask_s_ls,
             self.mask_l_ls,
-            *self.gear,
-            *self.gear_ls,
+            &self.gear,
+            &self.gear_ls,
         );
         (hash, start + count)
     }
@@ -759,8 +759,8 @@ impl<R: Read> StreamCDC<R> {
                 self.mask_l,
                 self.mask_s_ls,
                 self.mask_l_ls,
-                *self.gear,
-                *self.gear_ls,
+                &self.gear,
+                &self.gear_ls,
             );
             if count == 0 {
                 Err(Error::Empty)

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -251,7 +251,7 @@ const GEAR_LS: [u64; 256] = [
 
 // Produce the gear table (and left-shifted gear table) in which the values have
 // been XOR'd with the given seed.
-fn get_gear_with_seed(seed: u64) -> (Box<[u64; 256]>, Box<[u64; 256]>) {
+pub fn get_gear_with_seed(seed: u64) -> (Box<[u64; 256]>, Box<[u64; 256]>) {
     let mut gear = Box::new(GEAR);
     let mut gear_ls = Box::new(GEAR_LS);
     if seed > 0 {

--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -577,7 +577,7 @@ impl From<Error> for std::io::Error {
         match error {
             Error::IoError(ioerr) => ioerr,
             Error::Empty => Self::from(std::io::ErrorKind::UnexpectedEof),
-            Error::Other(str) => Self::new(std::io::ErrorKind::Other, str),
+            Error::Other(str) => Self::other(str),
         }
     }
 }


### PR DESCRIPTION
Hi there! 👋

I might be missing something, but it seems like the latest update made using `v2020::cut()` on its own a bit trickier than before. It now depends on `gear` and `gear_ls`, which are initialized by `v2020::get_gear_with_seed`—but that function is currently private.

Is there a particular reason why `v2020::get_gear_with_seed` is private? Just wanted to check in case that's intentional.

----

If it was just an oversight, I'd like to propose making it public with this small change. Thanks for the great library!
