### PR TITLE
v2020::Chunker: emit the tail instead of dropping it; tidy table conversion; add coverage test

### DIFF
--- a/src/v2020/mod.rs
+++ b/src/v2020/mod.rs
@@ -744,10 +744,18 @@ impl Chunker {
     /// without materializing the chunk slice. Use this when you only need the
     /// offsets/lengths (e.g. to build an extent map).
     pub fn for_each_boundary(&self, source: &[u8], mut f: impl FnMut(usize, usize, u64)) {
+        // Convert the GEAR tables to fixed-size arrays once, here, instead of
+        // re-running `try_into` inside the public `cut_gear` on every chunk.
+        let gear: &[u64; 256] = (&*self.gear)
+            .try_into()
+            .expect("GEAR table must have 256 entries");
+        let gear_ls: &[u64; 256] = (&*self.gear_ls)
+            .try_into()
+            .expect("GEAR_LS table must have 256 entries");
         let mut processed = 0usize;
         let mut remaining = source.len();
         while remaining > 0 {
-            let (hash, count) = cut_gear(
+            let (hash, count) = cut_gear_arr(
                 &source[processed..processed + remaining],
                 self.min_size,
                 self.avg_size,
@@ -756,17 +764,22 @@ impl Chunker {
                 self.mask_l,
                 self.mask_s_ls,
                 self.mask_l_ls,
-                &self.gear,
-                &self.gear_ls,
+                gear,
+                gear_ls,
             );
-            let cutpoint = processed + count;
-            if cutpoint == processed {
+            // `cut_gear` always makes progress on a non-empty slice for a valid
+            // `min_size` (>= MINIMUM_MIN). A zero count is only reachable with an
+            // invalid `min_size`, which the constructor already debug-asserts;
+            // if it ever happens, emit the remainder as one final chunk rather
+            // than silently dropping the rest of the source.
+            if count == 0 {
+                debug_assert!(false, "cut_gear made no progress on a non-empty source");
+                f(processed, remaining, hash);
                 break;
             }
-            let length = cutpoint - processed;
-            f(processed, length, hash);
-            processed = cutpoint;
-            remaining -= length;
+            f(processed, count, hash);
+            processed += count;
+            remaining -= count;
         }
     }
 }
@@ -1371,6 +1384,35 @@ mod tests {
             got.push(Chunk { hash, offset, length });
         });
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_chunker_covers_every_byte() {
+        // Guards against silently dropping the tail: the emitted chunks must be
+        // contiguous and cover the whole source exactly, for a range of sizes
+        // including sub-min and all-zeros inputs.
+        let fixture = fs::read("test/fixtures/SekienAkashita.jpg").unwrap();
+        let cases: [&[u8]; 5] = [
+            &[],
+            &[0u8; 10],          // shorter than min_size -> one (0, len) chunk
+            &[0u8; 50_000],      // all zeros -> max-size chunks
+            &fixture,
+            &fixture[..4096],    // exactly min_size
+        ];
+        let chunker = Chunker::new(4096, 16384, 65535);
+        for src in cases {
+            let mut next = 0usize;
+            let mut total = 0usize;
+            chunker.for_each_chunk(src, |offset, length, _hash, bytes| {
+                assert_eq!(offset, next, "chunks must be contiguous");
+                assert_eq!(bytes.len(), length);
+                assert_eq!(bytes, &src[offset..offset + length]);
+                next += length;
+                total += length;
+            });
+            assert_eq!(total, src.len(), "every byte must be emitted exactly once");
+            assert_eq!(next, src.len());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two small fixes to the `Chunker` added in #44, from @ciehanski's review, plus a test.

**1. Do not silently drop the tail.** `for_each_boundary`'s `count == 0` guard used to `break` silently, which would drop the remaining bytes with no callback to the caller. For a valid `min_size` (>= `MINIMUM_MIN`) on a non-empty source, `cut_gear` always returns `count > 0`, so this was unreachable in practice (and it mirrored the `FastCDC` iterator's `cutpoint == 0` handling) — but it should not drop bytes regardless. It now `debug_assert!`s and emits the remainder as one final chunk.

**2. Convert the GEAR tables once, not per chunk.** `for_each_boundary` called the public `cut_gear` in its loop, which re-runs `try_into().expect(...)` on both tables every iteration. `Chunker` already holds the tables, so it now converts them once up front and calls the inner `cut_gear_arr` directly.

**3. Add `test_chunker_covers_every_byte`.** Asserts the emitted chunks are contiguous and cover the source exactly, across empty / sub-minimum / all-zeros / fixture / exactly-`min_size` inputs.

No change to cut points — the existing fixture tests (exact cut points + BLAKE3 digests) and the `Chunker`-vs-`FastCDC` equality tests still pass.

<sub>🤖 Developed with Claude Code.</sub>